### PR TITLE
Change operator to allow major semantic changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php" : ">=5.6.0",
-        "league/oauth2-client": "^1.0"
+        "league/oauth2-client": ">=1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It appears the change to allow for earlier versions of the league/oauth2-client library. The composer.lock and composer.json seem to be out of sync, so I am assuming this was a quick fix without testing. 

The operator prefixing the version (^) uses semantic versioning to limit usage where there may be breaking changes. Due to this, I suggest changing the caret to a good ol' ">=". 

This causes problems specifically because if you're using the League client with one API, you probably use it with multiple APIs, and it creates conflicts using the older version when you're already using the new version.

Anyway, let me know if you have any questions. It's super simple, and I didn't create a new lock file (in the PR). I figured I would leave that up to you.


https://github.com/unsplash/unsplash-php/issues/60#issuecomment-322565142